### PR TITLE
fix(ui): normalize em-dash to hyphen across frontend components

### DIFF
--- a/frontend/src/components/analysis/TimelineView.tsx
+++ b/frontend/src/components/analysis/TimelineView.tsx
@@ -14,7 +14,7 @@ interface TimelineViewProps {
 }
 
 function formatDate(iso: string): string {
-  if (!iso) return "—";
+  if (!iso) return "-";
   try {
     const d = new Date(iso);
     if (isNaN(d.getTime())) return iso;

--- a/frontend/src/components/entity/EntityDetail.tsx
+++ b/frontend/src/components/entity/EntityDetail.tsx
@@ -68,7 +68,7 @@ export function EntityDetail({ entityId, onClose }: EntityDetailProps) {
             ).map(([key, value]) => (
               <div key={key} className={styles.property}>
                 <span className={styles.propKey}>{key}</span>
-                <span className={styles.propValue}>{String(value ?? "—")}</span>
+                <span className={styles.propValue}>{String(value ?? "-")}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/components/journey/JourneyPanel.tsx
+++ b/frontend/src/components/journey/JourneyPanel.tsx
@@ -156,7 +156,7 @@ export function JourneyPanel() {
               </a>
               <span style={{ fontSize: 9, color: "#475569" }}>
                 {new Date(e.timestamp).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
-                {e.description && (" — " + e.description.slice(0, 40))}
+                {e.description && (" - " + e.description.slice(0, 40))}
               </span>
             </div>
             <button

--- a/frontend/src/components/landing/ReportsShowcase.tsx
+++ b/frontend/src/components/landing/ReportsShowcase.tsx
@@ -13,7 +13,7 @@ interface Report {
 const REPORTS: Report[] = [
   {
     id: "patense",
-    title: "Grupo Patense — Rede Societaria e Financeira",
+    title: "Grupo Patense - Rede Societária e Financeira",
     date: "2026-03-01",
     description: "Pesquisa de 13 empresas interligadas com R$217M em financiamentos BNDES e R$2.15B em divida ativa.",
     tags: ["BNDES", "rede societaria", "divida ativa"],

--- a/frontend/src/components/landing/StatsBar.tsx
+++ b/frontend/src/components/landing/StatsBar.tsx
@@ -84,7 +84,7 @@ export function StatsBar() {
       <div className={styles.bar}>
         <div className={styles.inner}>
           <div className={styles.item}>
-            <span className={styles.number}>{"\u2014"}</span>
+            <span className={styles.number}>{"-"}</span>
             <span className={styles.label}>{t("common.loading")}</span>
           </div>
         </div>

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -80,7 +80,7 @@ export function Activity() {
     <div className={styles.container}>
       <h1 className={styles.title}>Feed de Atividades</h1>
       <p className={styles.subtitle}>
-        Todas as ações do sistema em tempo real — Mycelium Event Trail
+        Todas as ações do sistema em tempo real - Mycelium Event Trail
       </p>
 
       <div className={styles.statsBar}>


### PR DESCRIPTION
## Summary

Normaliza em-dash (—) para hífen (-) em 6 componentes frontend para consistência visual.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/analysis/TimelineView.tsx` | `"—"` → `"-"` |
| `frontend/src/components/entity/EntityDetail.tsx` | `"—"` → `"-"` |
| `frontend/src/components/journey/JourneyPanel.tsx` | `" — "` → `" - "` |
| `frontend/src/components/landing/ReportsShowcase.tsx` | `"—"` → `"-"` no título |
| `frontend/src/components/landing/StatsBar.tsx` | `"\u2014"` → `"-"` |
| `frontend/src/pages/Activity.tsx` | `"—"` → `"-"` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized punctuation formatting across the interface by replacing em dashes with hyphens in multiple UI locations for visual consistency.
  * Updated report title with improved character formatting and diacritical marks for proper text representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->