### PR TITLE
PR: Add automated BR-ACC upstream monitor (Issue #9 — TASK-013)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,12 +41,14 @@ VITE_PATTERNS_ENABLED=false
 # Optional: Google Cloud (for Base dos Dados / TSE BigQuery)
 # GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json
 
-# External API keys (required for chat agent tools)
-# PORTAL_TRANSPARENCIA_API_KEY=  # gov.br Portal da Transparência
-# DATAJUD_API_KEY=               # CNJ DataJud (judicial data)
-# BRAVE_API_KEY=                 # Brave Search API
-# OPENROUTER_API_KEY=            # OpenRouter (LLM for chat agent)
-
 # Optional ETL source tokens
 # WORLD_BANK_API_KEY=
 # EU_SANCTIONS_TOKEN=
+
+# BR-ACC upstream monitor (scripts/bracc-monitor.ts, 2x/day)
+# GITHUB_TOKEN= or GH_TOKEN= — required for GitHub API (forks, PRs, issues)
+# REPORT_PATH= — optional; default scripts/bracc-monitor-report.json
+# STATE_PATH= — optional; default scripts/.bracc-monitor-state.json
+# DISCORD_WEBHOOK_URL= — optional; webhook for notifications
+# TELEGRAM_BOT_TOKEN= — optional; with TELEGRAM_CHAT_ID for Telegram alerts
+# TELEGRAM_CHAT_ID=

--- a/.github/workflows/bracc-monitor.yml
+++ b/.github/workflows/bracc-monitor.yml
@@ -1,0 +1,69 @@
+# BR-ACC Upstream Monitor — TASK-013
+# Runs 2x/day (06:00 and 18:00 UTC-3 = 09:00 and 21:00 UTC); optional Discord/Telegram notifications.
+name: BR-ACC Monitor
+
+on:
+  schedule:
+    # 09:00 UTC and 21:00 UTC = 06:00 and 18:00 UTC-3
+    - cron: '0 9,21 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    name: Upstream monitor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: scripts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore monitor state
+        uses: actions/cache/restore@v4
+        id: cache-state
+        with:
+          path: scripts/.bracc-monitor-state.json
+          key: bracc-monitor-state-${{ github.repository }}-${{ github.run_id }}
+          restore-keys: |
+            bracc-monitor-state-${{ github.repository }}-
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: scripts/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run monitor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: npm run monitor
+
+      - name: Save monitor state
+        uses: actions/cache/save@v4
+        if: success() || failure()
+        with:
+          path: scripts/.bracc-monitor-state.json
+          key: bracc-monitor-state-${{ github.repository }}-${{ github.run_id }}
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bracc-monitor-report
+          path: scripts/bracc-monitor-report.json
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ data/cnpj/reference/*
 audit-results/
 scripts/audit-prompts/
 
+# BR-ACC monitor (generated state and report)
+scripts/.bracc-monitor-state.json
+scripts/bracc-monitor-report.json
+
 # Screenshots and images (large binary files)
 *.png
 !docs/brand/wtg-header.png
@@ -95,4 +99,3 @@ data/tse/
 CLAUDE.md
 AGENTS.md
 AGENTS*.md
-docs/ECOSYSTEM_DIAGNOSTIC_2026-03.md

--- a/frontend/src/lib/journey.ts
+++ b/frontend/src/lib/journey.ts
@@ -38,7 +38,7 @@ export function getJourney(): JourneyData {
       const data = JSON.parse(raw) as JourneyData;
       if (data.version === 1 && Array.isArray(data.entries)) return data;
     }
-  } catch { /* corrupt data, reset */ }
+  } catch { /* invalid or malformed data, reset */ }
   return { version: 1, entries: [], createdAt: Date.now(), lastUpdated: Date.now() };
 }
 

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -75,7 +75,7 @@ export function Reports() {
         if (data.error) md += `\n**Erro:** ${data.error}`;
         setGenResult(md);
       }
-    } catch (e) {
+    } catch {
       setGenResult("Erro ao gerar relatório");
     } finally {
       setGenerating(false);

--- a/scripts/README-bracc-monitor.md
+++ b/scripts/README-bracc-monitor.md
@@ -1,0 +1,79 @@
+# BR-ACC Upstream Monitor (TASK-013)
+
+Script que roda **2x ao dia** e monitora o upstream **World-Open-Graph/br-acc**: forks, PRs abertos, issues e sugestões de alinhamento do `TASKS.md` com PRs mergeados. Gera um relatório JSON e opcionalmente envia notificações para Discord e Telegram.
+
+## O que o script faz
+
+- **Forks:** Lista forks do upstream, marca os novos desde a última execução, compara cada fork com o upstream (diff de arquivos) e categoriza por área (tradução, ETL, frontend, API, infra, docs).
+- **Pull Requests:** Lista PRs abertos no upstream, detecta possíveis duplicatas (mesmo conjunto de arquivos), categoriza por tipo e notifica quando há PR novo.
+- **Issues:** Lista issues abertas no upstream e faz cross-reference com as issues do nosso repositório (`enioxt/EGOS-Inteligencia`) para sinalizar possível trabalho duplicado.
+- **Roadmap:** Lê o `TASKS.md` do repositório, lista PRs mergeados no upstream desde a última execução e sugere vínculos TASK-XXX ↔ PR (apenas relatório; não altera o `TASKS.md` automaticamente).
+
+## Requisitos
+
+- **Node.js 20+**
+- **Variável de ambiente:** `GITHUB_TOKEN` ou `GH_TOKEN` (obrigatória para a GitHub API).
+
+## Uso local
+
+```bash
+cd scripts
+npm ci
+export GITHUB_TOKEN=ghp_...
+npm run monitor
+```
+
+O relatório é escrito em `scripts/bracc-monitor-report.json`. O estado (forks/PRs já conhecidos) fica em `scripts/.bracc-monitor-state.json` para a próxima execução.
+
+## Variáveis de ambiente
+
+| Variável | Obrigatória | Descrição |
+|----------|-------------|-----------|
+| `GITHUB_TOKEN` ou `GH_TOKEN` | Sim | Token da GitHub API (scope `repo` para repositórios públicos basta o token padrão). |
+| `REPORT_PATH` | Não | Caminho do relatório JSON (padrão: `scripts/bracc-monitor-report.json`). |
+| `STATE_PATH` | Não | Caminho do arquivo de estado (padrão: `scripts/.bracc-monitor-state.json`). |
+| `DISCORD_WEBHOOK_URL` | Não | URL do webhook do Discord para notificações. |
+| `TELEGRAM_BOT_TOKEN` | Não | Token do bot do Telegram (usado com `TELEGRAM_CHAT_ID`). |
+| `TELEGRAM_CHAT_ID` | Não | ID do chat/canal para onde enviar as mensagens. |
+
+Ver também `.env.example` na raiz do repositório.
+
+## Rodar no GitHub Actions
+
+O workflow **BR-ACC Monitor** (`.github/workflows/bracc-monitor.yml`) está configurado para:
+
+- **Agendamento:** 2x ao dia às **09:00 UTC** e **21:00 UTC** (06:00 e 18:00 em UTC-3).
+- **Manual:** Aba **Actions** → workflow "BR-ACC Monitor" → "Run workflow".
+
+O estado é persistido entre execuções via cache do Actions. O relatório é publicado como artefato (**bracc-monitor-report**) com retenção de 14 dias.
+
+Para receber notificações no Discord/Telegram, configure os secrets do repositório:
+
+- `DISCORD_WEBHOOK_URL`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+
+## Rodar no servidor (Contabo / cron)
+
+Para rodar em um servidor com cron (por exemplo Contabo), use Node 20+ e carregue as variáveis de ambiente (por exemplo a partir de um `.env` em `/opt/bracc` ou no crontab):
+
+```bash
+# Exemplo crontab (06:00 e 18:00 UTC-3)
+0 6,18 * * * cd /opt/bracc/scripts && . ../.env 2>/dev/null; npm run monitor >> /var/log/bracc-monitor.log 2>&1
+```
+
+Defina `STATE_PATH` para um caminho persistente (por exemplo `/opt/bracc/scripts/.bracc-monitor-state.json`) para que o script reconheça forks e PRs já vistos entre execuções.
+
+## On-demand via bot
+
+A issue original menciona execução sob demanda por comando do bot. O código do bot (Discord/Telegram) fica fora deste repositório. Para disparar o monitor por comando (ex.: `/monitor-bracc`), o bot pode chamar a API do GitHub para acionar o workflow:
+
+- Endpoint: `POST /repos/{owner}/{repo}/actions/workflows/bracc-monitor.yml/dispatches`
+- Token com permissão `actions: write`.
+
+Não é necessária alteração no script; basta o bot usar o `workflow_dispatch` do Actions.
+
+## Limitações
+
+- **Primeira execução:** Sem estado anterior, o relatório JSON ainda preenche o campo `new_since` por item (forks e PRs podem aparecer com `new_since: true`), mas as notificações (Discord/Telegram) são suprimidas nessa execução inicial para evitar spam; a partir da segunda execução, itens realmente novos disparam notificações.
+- **TASKS.md:** Apenas gera sugestões de vínculo no relatório; não atualiza o `TASKS.md` automaticamente.

--- a/scripts/bracc-monitor.ts
+++ b/scripts/bracc-monitor.ts
@@ -1,0 +1,579 @@
+#!/usr/bin/env npx tsx
+/**
+ * BR-ACC Upstream Monitor — TASK-013
+ * Runs 2x/day; monitors forks, PRs, issues, TASKS.md vs merged PRs.
+ * Output: bracc-monitor-report.json + optional Discord/Telegram notifications.
+ */
+
+import "dotenv/config";
+import { Octokit } from "@octokit/rest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const UPSTREAM_OWNER = "World-Open-Graph";
+const UPSTREAM_REPO = "br-acc";
+const OUR_REPO_OWNER = "enioxt";
+const OUR_REPO = "EGOS-Inteligencia";
+
+const REPORT_PATH = process.env.REPORT_PATH ?? path.join(__dirname, "bracc-monitor-report.json");
+const STATE_PATH = process.env.STATE_PATH ?? path.join(__dirname, ".bracc-monitor-state.json");
+
+// ---------------------------------------------------------------------------
+// Config and state
+// ---------------------------------------------------------------------------
+
+function getToken(): string {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!token) {
+    throw new Error("Set GITHUB_TOKEN or GH_TOKEN to run the monitor.");
+  }
+  return token;
+}
+
+interface MonitorState {
+  lastRun: string; // ISO
+  knownForkIds: number[];
+  knownPRNumbers: number[];
+}
+
+function loadState(): MonitorState {
+  try {
+    const raw = fs.readFileSync(STATE_PATH, "utf-8");
+    return JSON.parse(raw) as MonitorState;
+  } catch {
+    return {
+      lastRun: "",
+      knownForkIds: [],
+      knownPRNumbers: [],
+    };
+  }
+}
+
+function saveState(state: MonitorState): void {
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Categorize by file paths (forks + PRs)
+// ---------------------------------------------------------------------------
+
+const CATEGORY_MAP: Array<{ pattern: RegExp | string; category: string }> = [
+  { pattern: /^frontend\//, category: "frontend" },
+  { pattern: /^api\//, category: "API" },
+  { pattern: /^etl\//, category: "ETL" },
+  { pattern: /^infra\//, category: "infra" },
+  { pattern: /^docs\//, category: "docs" },
+  { pattern: /\.md$/i, category: "docs" },
+  { pattern: /(?:i18n|locales?|locale)\//i, category: "tradução" },
+  { pattern: /\.(json|yaml|yml)$/, category: "docs" }, // config/docs-ish
+];
+
+function categorizeFilesSet(files: string[]): string[] {
+  const categories = new Set<string>();
+  for (const f of files) {
+    let matched = false;
+    for (const { pattern, category } of CATEGORY_MAP) {
+      if (typeof pattern === "string" ? f.startsWith(pattern) : pattern.test(f)) {
+        categories.add(category);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) categories.add("other");
+  }
+  return [...categories].length ? [...categories] : ["other"];
+}
+
+// ---------------------------------------------------------------------------
+// Forks
+// ---------------------------------------------------------------------------
+
+interface ForkEntry {
+  id: number;
+  full_name: string;
+  html_url: string;
+  created_at: string;
+  new_since: boolean;
+  files_changed: string[];
+  categories: string[];
+}
+
+async function fetchForks(octokit: Octokit): Promise<ForkEntry[]> {
+  const forks: ForkEntry[] = [];
+  const state = loadState();
+  const pageSize = 30;
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const { data: list } = await octokit.repos.listForks({
+      owner: UPSTREAM_OWNER,
+      repo: UPSTREAM_REPO,
+      sort: "newest",
+      per_page: pageSize,
+      page,
+    });
+    if (list.length === 0) hasMore = false;
+    for (const fork of list) {
+      const new_since = !state.knownForkIds.includes(fork.id);
+      let files_changed: string[] = [];
+      let categories: string[] = ["other"];
+
+      try {
+        const forkBranch = fork.default_branch ?? "main";
+        const upstreamBase = "main"; // upstream default branch
+        const { data: compare } = await octokit.repos.compareCommitsWithBasehead({
+          owner: UPSTREAM_OWNER,
+          repo: UPSTREAM_REPO,
+          basehead: `${upstreamBase}...${fork.owner.login}:${forkBranch}`,
+        });
+        if (compare.files) {
+          files_changed = compare.files.map((f) => f.filename).filter(Boolean);
+          categories = categorizeFilesSet(files_changed);
+        }
+      } catch {
+        // Fork may be empty or same as upstream
+      }
+
+      forks.push({
+        id: fork.id,
+        full_name: fork.full_name ?? `${fork.owner.login}/${fork.name}`,
+        html_url: fork.html_url ?? `https://github.com/${fork.full_name}`,
+        created_at: fork.created_at ?? "",
+        new_since,
+        files_changed,
+        categories,
+      });
+    }
+    page++;
+    if (list.length < pageSize) hasMore = false;
+  }
+
+  return forks;
+}
+
+// ---------------------------------------------------------------------------
+// Pull Requests (open, with duplicate detection and categories)
+// ---------------------------------------------------------------------------
+
+interface PREntry {
+  number: number;
+  title: string;
+  html_url: string;
+  user: string;
+  labels: string[];
+  files: string[];
+  categories: string[];
+  duplicate_of?: number[]; // other PR numbers touching same file set
+  new_since: boolean;
+}
+
+async function fetchOpenPRs(octokit: Octokit): Promise<PREntry[]> {
+  const state = loadState();
+  const prs: PREntry[] = [];
+  let page = 1;
+  const pageSize = 30;
+
+  while (true) {
+    const { data: list } = await octokit.pulls.list({
+      owner: UPSTREAM_OWNER,
+      repo: UPSTREAM_REPO,
+      state: "open",
+      per_page: pageSize,
+      page,
+    });
+    if (list.length === 0) break;
+
+    for (const pr of list) {
+      let files: string[] = [];
+      try {
+        const filesData = await octokit.paginate(octokit.pulls.listFiles, {
+          owner: UPSTREAM_OWNER,
+          repo: UPSTREAM_REPO,
+          pull_number: pr.number,
+        });
+        files = filesData.map((f) => f.filename).filter(Boolean);
+      } catch {
+        // ignore
+      }
+      const categories = categorizeFilesSet(files);
+      const labels = (pr.labels ?? []).map((l) => (typeof l === "object" && l.name ? l.name : String(l)));
+
+      prs.push({
+        number: pr.number,
+        title: pr.title ?? "",
+        html_url: pr.html_url ?? `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pull/${pr.number}`,
+        user: pr.user?.login ?? "",
+        labels,
+        files,
+        categories,
+        new_since: !state.knownPRNumbers.includes(pr.number),
+      });
+    }
+    if (list.length < pageSize) break;
+    page++;
+  }
+
+  // Duplicate detection: group by sorted file set fingerprint
+  const byFingerprint = new Map<string, number[]>();
+  for (const pr of prs) {
+    const key = pr.files.slice().sort().join("\n") || `title:${pr.title}`;
+    const arr = byFingerprint.get(key) ?? [];
+    arr.push(pr.number);
+    byFingerprint.set(key, arr);
+  }
+  for (const pr of prs) {
+    const key = pr.files.slice().sort().join("\n") || `title:${pr.title}`;
+    const group = byFingerprint.get(key) ?? [];
+    if (group.length > 1) {
+      pr.duplicate_of = group.filter((n) => n !== pr.number);
+    }
+  }
+
+  return prs;
+}
+
+// ---------------------------------------------------------------------------
+// Issues (upstream + cross-ref with our repo)
+// ---------------------------------------------------------------------------
+
+interface IssueEntry {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  possible_duplicate_of?: string; // our repo issue URL or number
+}
+
+async function fetchIssues(octokit: Octokit): Promise<{ upstream: IssueEntry[]; ours: IssueEntry[]; cross_ref: Array<{ upstream: IssueEntry; our: IssueEntry }> }> {
+  const upstream: IssueEntry[] = [];
+  let page = 1;
+  const pageSize = 50;
+
+  while (true) {
+    const { data: list } = await octokit.issues.listForRepo({
+      owner: UPSTREAM_OWNER,
+      repo: UPSTREAM_REPO,
+      state: "open",
+      per_page: pageSize,
+      page,
+    });
+    if (list.length === 0) break;
+    const issues = list.filter((i) => !i.pull_request);
+    if (issues.length === 0) {
+      page++;
+      continue;
+    }
+    for (const i of issues) {
+      upstream.push({
+        number: i.number,
+        title: i.title ?? "",
+        html_url: i.html_url ?? `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues/${i.number}`,
+        state: i.state ?? "open",
+      });
+    }
+    if (list.length < pageSize) break;
+    page++;
+  }
+
+  const ours: IssueEntry[] = [];
+  page = 1;
+  while (true) {
+    try {
+      const { data: list } = await octokit.issues.listForRepo({
+        owner: OUR_REPO_OWNER,
+        repo: OUR_REPO,
+        state: "open",
+        per_page: pageSize,
+        page,
+      });
+      if (list.length === 0) break;
+      const issues = list.filter((i) => !i.pull_request);
+      if (issues.length === 0) {
+        page++;
+        continue;
+      }
+      for (const i of issues) {
+        ours.push({
+          number: i.number,
+          title: i.title ?? "",
+          html_url: i.html_url ?? `https://github.com/${OUR_REPO_OWNER}/${OUR_REPO}/issues/${i.number}`,
+          state: i.state ?? "open",
+        });
+      }
+      if (list.length < pageSize) break;
+      page++;
+    } catch {
+      break;
+    }
+  }
+
+  // Simple keyword cross-ref: normalize title to words, match if significant overlap
+  const cross_ref: Array<{ upstream: IssueEntry; our: IssueEntry }> = [];
+  const toWords = (t: string) =>
+    t
+      .toLowerCase()
+      .replace(/[^\w\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2);
+  for (const u of upstream) {
+    const uWords = new Set(toWords(u.title));
+    for (const o of ours) {
+      const oWords = toWords(o.title);
+      const overlap = oWords.filter((w) => uWords.has(w)).length;
+      if (overlap >= 2 && overlap >= Math.min(uWords.size, oWords.length) * 0.3) {
+        cross_ref.push({ upstream: u, our: o });
+        u.possible_duplicate_of = o.html_url;
+      }
+    }
+  }
+
+  return { upstream, ours, cross_ref };
+}
+
+// ---------------------------------------------------------------------------
+// Roadmap: TASKS.md vs merged PRs
+// ---------------------------------------------------------------------------
+
+interface TaskMatch {
+  task_id: string;
+  status: string;
+  possible_pr: { number: number; title: string; html_url: string };
+}
+
+function parseTASKS(content: string): Array<{ id: string; status: string; title_snippet: string }> {
+  const tasks: Array<{ id: string; status: string; title_snippet: string }> = [];
+  const taskLine = /^### (TASK-\d+):\s*(.*?)(?:\s*✅|\s*⬜|\s*⏳|$)/im;
+  const statusMatch = /(✅|⬜|⏳)/;
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(taskLine);
+    if (m) {
+      const status = statusMatch.exec(lines[i])?.[1] ?? "⬜";
+      tasks.push({
+        id: m[1],
+        status,
+        title_snippet: (m[2] ?? "").replace(/\s*\(.*\)\s*$/, "").trim().slice(0, 80),
+      });
+    }
+  }
+  return tasks;
+}
+
+async function fetchRoadmapSuggestions(
+  octokit: Octokit,
+  state: MonitorState
+): Promise<TaskMatch[]> {
+  const tasksPath = path.join(REPO_ROOT, "TASKS.md");
+  let tasksContent: string;
+  try {
+    tasksContent = fs.readFileSync(tasksPath, "utf-8");
+  } catch {
+    return [];
+  }
+  const tasks = parseTASKS(tasksContent);
+  const since = state.lastRun ? new Date(state.lastRun) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const merged: Array<{ number: number; title: string; html_url: string; body: string }> = [];
+  let page = 1;
+  while (true) {
+    const { data: list } = await octokit.pulls.list({
+      owner: UPSTREAM_OWNER,
+      repo: UPSTREAM_REPO,
+      state: "closed",
+      sort: "updated",
+      direction: "desc",
+      per_page: 30,
+      page,
+    });
+    for (const pr of list) {
+      if (!pr.merged_at) continue;
+      const mergedAt = new Date(pr.merged_at);
+      if (mergedAt < since) continue;
+      merged.push({
+        number: pr.number,
+        title: pr.title ?? "",
+        html_url: pr.html_url ?? `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pull/${pr.number}`,
+        body: pr.body ?? "",
+      });
+    }
+    if (list.length < 30) break;
+    page++;
+  }
+
+  const suggestions: TaskMatch[] = [];
+  const taskWords = (t: string) =>
+    t
+      .toLowerCase()
+      .replace(/[^\w\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2);
+
+  for (const task of tasks) {
+    if (task.status === "✅") continue;
+    const words = new Set(taskWords(task.title_snippet));
+    for (const pr of merged) {
+      const prText = `${pr.title} ${pr.body}`;
+      const prWords = taskWords(prText);
+      const overlap = prWords.filter((w) => words.has(w)).length;
+      if (overlap >= 2 && overlap >= Math.min(words.size, prWords.length) * 0.2) {
+        suggestions.push({
+          task_id: task.id,
+          status: task.status,
+          possible_pr: { number: pr.number, title: pr.title, html_url: pr.html_url },
+        });
+        break; // one suggestion per task
+      }
+    }
+  }
+  return suggestions;
+}
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
+async function sendWebhookRequest(
+  url: string,
+  options: { method: string; body: string },
+  callerName: string
+): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: options.method,
+      headers: { "Content-Type": "application/json" },
+      body: options.body,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      console.warn(`[${callerName}] webhook request failed: status=${response.status}`);
+      return;
+    }
+  } catch (e) {
+    clearTimeout(timeoutId);
+    const message = e instanceof Error ? e.message : "unknown error";
+    console.warn(`[${callerName}] webhook request error: ${message}`);
+  }
+}
+
+async function notifyDiscord(text: string): Promise<void> {
+  const url = process.env.DISCORD_WEBHOOK_URL;
+  if (!url) return;
+  await sendWebhookRequest(
+    url,
+    { method: "POST", body: JSON.stringify({ content: text }) },
+    "notifyDiscord"
+  );
+}
+
+async function notifyTelegram(text: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) return;
+  const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
+  await sendWebhookRequest(
+    telegramUrl,
+    {
+      method: "POST",
+      body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+    },
+    "notifyTelegram"
+  );
+}
+
+async function sendRelevantNotifications(report: Report): Promise<void> {
+  const parts: string[] = [];
+  const newForks = report.forks.filter((f) => f.new_since);
+  const newPRs = report.pull_requests.filter((p) => p.new_since);
+  if (newForks.length) {
+    parts.push(`🆕 Forks novos: ${newForks.length}\n${newForks.slice(0, 5).map((f) => `• ${f.full_name}`).join("\n")}`);
+  }
+  if (newPRs.length) {
+    parts.push(
+      `📌 PRs novos no upstream: ${newPRs.length}\n${newPRs.slice(0, 5).map((p) => `• #${p.number} ${p.title}\n  ${p.html_url}`).join("\n\n")}`
+    );
+  }
+  if (report.roadmap_suggestions.length) {
+    parts.push(
+      `📋 Sugestões TASKS ↔ PRs: ${report.roadmap_suggestions.length}\n${report.roadmap_suggestions
+        .slice(0, 3)
+        .map((s) => `• ${s.task_id} ↔ PR #${s.possible_pr.number}`)
+        .join("\n")}`
+    );
+  }
+  if (parts.length === 0) return;
+  const text = `[BR-ACC Monitor]\n\n${parts.join("\n\n")}`;
+  await Promise.all([notifyDiscord(text), notifyTelegram(text)]);
+}
+
+// ---------------------------------------------------------------------------
+// Report type and main
+// ---------------------------------------------------------------------------
+
+interface Report {
+  generated_at: string;
+  upstream: string;
+  forks: ForkEntry[];
+  pull_requests: PREntry[];
+  issues: { upstream: IssueEntry[]; ours: IssueEntry[]; cross_ref_count: number };
+  roadmap_suggestions: TaskMatch[];
+}
+
+async function main(): Promise<void> {
+  const token = getToken();
+  const octokit = new Octokit({ auth: token });
+
+  const state = loadState();
+  const now = new Date().toISOString();
+
+  console.log("Fetching forks...");
+  const forks = await fetchForks(octokit);
+  console.log("Fetching open PRs...");
+  const pull_requests = await fetchOpenPRs(octokit);
+  console.log("Fetching issues...");
+  const issuesData = await fetchIssues(octokit);
+  console.log("Fetching roadmap suggestions...");
+  const roadmap_suggestions = await fetchRoadmapSuggestions(octokit, state);
+
+  const report: Report = {
+    generated_at: now,
+    upstream: `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`,
+    forks,
+    pull_requests,
+    issues: {
+      upstream: issuesData.upstream,
+      ours: issuesData.ours,
+      cross_ref_count: issuesData.cross_ref.length,
+    },
+    roadmap_suggestions,
+  };
+
+  fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2), "utf-8");
+  console.log("Report written to", REPORT_PATH);
+
+  // Update state for next run (first run: mark all as known so we don't notify)
+  const isFirstRun = !state.lastRun;
+  saveState({
+    lastRun: now,
+    knownForkIds: [...new Set([...state.knownForkIds, ...forks.map((f) => f.id)])],
+    knownPRNumbers: [...new Set([...state.knownPRNumbers, ...pull_requests.map((p) => p.number)])],
+  });
+
+  if (!isFirstRun) {
+    await sendRelevantNotifications(report);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,821 @@
+{
+  "name": "bracc-monitor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bracc-monitor",
+      "version": "1.0.0",
+      "dependencies": {
+        "@octokit/rest": "^21.0.2",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.1",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
+      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bracc-monitor",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Upstream BR-ACC monitor: forks, PRs, issues, TASKS sync",
+  "type": "module",
+  "scripts": {
+    "monitor": "tsx bracc-monitor.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@octokit/rest": "^21.0.2",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["bracc-monitor.ts", "*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implementa o **BR-ACC Monitor** (Issue #9 / TASK-013): um job automatizado que roda 2x/dia via GitHub Actions para monitorar forks, PRs e issues do upstream `World-Open-Graph/br-acc`, gerando um relatório JSON e (opcionalmente) notificações em Discord/Telegram.  
Esta PR contém apenas o **script + workflow + pequenos ajustes de frontend**, mantendo as atualizações de docs em uma PR separada.

Arquivos principais desta PR:
- `scripts/bracc-monitor.ts`, `scripts/package.json`, `scripts/package-lock.json`, `scripts/tsconfig.json`, `scripts/README-bracc-monitor.md`
- `.github/workflows/bracc-monitor.yml`, `.env.example`, `.gitignore`
- `frontend/src/lib/journey.ts`, `frontend/src/pages/Reports.tsx` (neutralidade + ESLint)

---

## Release metadata

**Release note (PT-BR):**

Adicionado job automatizado (BR-ACC Monitor) que roda 2x ao dia via GitHub Actions para monitorar forks, PRs e issues do upstream `World-Open-Graph/br-acc`, categorizando mudanças por área e gerando relatório JSON com sugestões de TASK↔PR; notificações em Discord/Telegram são opcionais e controladas por variáveis de ambiente.

**Release note (EN):**

Added an automated job (BR-ACC Monitor) that runs twice daily via GitHub Actions to monitor upstream `World-Open-Graph/br-acc` forks, PRs, and issues, categorizing changes by area and producing a JSON report with TASK↔PR suggestions; Discord/Telegram notifications are optional and controlled via environment variables.

**Release highlights (PT-BR, bullets with `|`):**

| Job 2x/dia (06:00 e 18:00 UTC-3) para monitorar forks, PRs e issues do upstream br-acc |
| Script TypeScript em `scripts/bracc-monitor.ts` com categorização por área (frontend, API, ETL, infra, docs, tradução) |
| Workflow `.github/workflows/bracc-monitor.yml` com schedule, cache de estado e artefato de relatório JSON |
| Notificações opcionais em Discord/Telegram com timeout e logging seguro, controladas por env vars |
| Pequenos ajustes de frontend (`journey.ts`, `Reports.tsx`) para neutralidade e ESLint |

**Release highlights (EN, bullets with `|`):**

| Twice-daily job (06:00 and 18:00 UTC-3) to monitor upstream br-acc forks, PRs, and issues |
| TypeScript script in `scripts/bracc-monitor.ts` with area-based categorization (frontend, API, ETL, infra, docs, translation) |
| `.github/workflows/bracc-monitor.yml` workflow with schedule, state cache, and JSON report artifact |
| Optional Discord/Telegram notifications with timeout and safe logging, controlled via env vars |
| Small frontend fixes (`journey.ts`, `Reports.tsx`) for neutrality and ESLint compliance |

**Included pattern IDs (comma-separated, or `none`):**  
none

**Technical changes (PT-BR, bullets with `|`):**

| Novo pacote Node em `scripts/` (`bracc-monitor`) com `@octokit/rest`, `dotenv`, `tsx`, `typescript` |
| Script `scripts/bracc-monitor.ts`: monitor de forks/PRs/issues, sugestão de TASK↔PR em JSON, estado incremental e notificações opcionais |
| Workflow `.github/workflows/bracc-monitor.yml` com schedule 09:00/21:00 UTC, cache de estado por `github.run_id` e upload de `bracc-monitor-report.json` |
| Atualização de `.env.example` e `.gitignore` para incluir variáveis do monitor e arquivos gerados (`STATE_PATH`/`REPORT_PATH`) |
| Frontend: ajuste de neutralidade em `journey.ts` (comentário) e correção de ESLint em `Reports.tsx` (catch sem variável não usada) |

**Technical changes (EN, bullets with `|`):**

| New Node package in `scripts/` (`bracc-monitor`) with `@octokit/rest`, `dotenv`, `tsx`, `typescript` |
| `scripts/bracc-monitor.ts`: monitors forks/PRs/issues, emits TASK↔PR suggestions in JSON, keeps incremental state and optional notifications |
| `.github/workflows/bracc-monitor.yml` with 09:00/21:00 UTC schedule, state cache keyed by `github.run_id`, and `bracc-monitor-report.json` artifact upload |
| `.env.example` and `.gitignore` updated to cover monitor env vars and generated files (`STATE_PATH`/`REPORT_PATH`) |
| Frontend: neutrality-adjusted comment in `journey.ts` and ESLint fix in `Reports.tsx` (unused catch variable removed) |

**Change type (choose one release label from taxonomy):**

- [ ] `release:major`
- [ ] `release:feature`
- [ ] `release:patterns`
- [ ] `release:api`
- [ ] `release:data`
- [ ] `release:privacy`
- [ ] `release:fix`
- [ ] `release:docs`
- [x] `release:infra`
- [ ] `release:security`

**Breaking change?**

- [x] No  
- [ ] Yes (describe migration/impact in summary)

---

## Validation

- [x] Local tests/checks passed for impacted scope  
  - `scripts/`: `npm run build` (TypeScript), geração de `package-lock.json` ok.  
  - Neutralidade: grep de palavras banidas passou após ajuste em `frontend/src/lib/journey.ts`.  
  - Frontend: `npx eslint src/` em `frontend/` com apenas warnings existentes (react-hooks) e sem novos erros.  
- [ ] CI and Security checks are green  
- [ ] Exactly one release label is set on this PR (`release:infra`)

---

## Public safety and compliance checklist

- [x] No personal identifier exposure was introduced  
- [x] `PUBLIC_MODE` behavior was reviewed (if relevant) — monitor roda apenas em GitHub Actions/cron e não expõe novos endpoints públicos  
- [x] Public boundary gate is green — nenhuma mudança em APIs públicas ou dados de demonstração  
- [x] Public endpoints and demo data contain no personal data fields  
- [x] Legal/policy docs were reviewed for scope-impacting changes — esta PR não altera docs; atualizações de docs estão em PR separada  
- [x] Snapshot boundary remains compliant with `docs/release/public_boundary_matrix.csv` — script e workflow vivem em `scripts/` e `.github/workflows/` sem expandir o boundary público

---

## Risk and rollback

**Riscos principais:**

- Consumo de minutos do GitHub Actions (2 execuções/dia) — especialmente em forks com limites menores.  
- Notificações em Discord/Telegram mal configuradas podem gerar ruído se canais incorretos forem usados.  
- Uso incorreto de tokens (`GITHUB_TOKEN`, webhooks) pode causar falhas silenciosas do monitor se não configurados.

**Rollback:**

- Desativar o workflow `BR-ACC Monitor` na aba **Actions** (ou remover `.github/workflows/bracc-monitor.yml`).  
- Remover o pacote e script do monitor (`scripts/bracc-monitor.ts`, `scripts/package.json`, `scripts/package-lock.json`, `scripts/tsconfig.json`, `scripts/README-bracc-monitor.md`) e entradas relacionadas em `.env.example` / `.gitignore`.  
- Os pequenos ajustes de frontend (`journey.ts`, `Reports.tsx`) são backward-compatible; se necessário, podem ser revertidos individualmente via `git revert` do commit desta PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BR-ACC Upstream Monitor with automated GitHub Actions workflow to track upstream forks, pull requests, issues, and roadmap alignment.
  * Optional Discord and Telegram notifications for new upstream activity.
  * Structured JSON report generation with state persistence.

* **Documentation**
  * Added comprehensive guide for the monitor script and configuration.

* **Chores**
  * Updated environment configuration and added TypeScript/Node.js build setup for scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->